### PR TITLE
fix(radio): reject off-grid frequencies in freq_to_channel (closes #4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,37 @@ All notable changes to `adb-android-control` are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- `radio.freq_to_channel` no longer fabricates channel numbers for
+  off-grid Wi-Fi frequencies. Previously, frequencies in the 2.4 GHz
+  gap band (2473–2483 MHz) and any non-5-MHz-aligned 5 GHz / 6 GHz
+  frequency would return invalid channel numbers (e.g. 13 from 2473,
+  15 from 2483, 34 from 5171, 164 from 5824). They now correctly
+  return `0` ("unknown"). The function validates input alignment to
+  the canonical IEEE 802.11 channel-center grid in addition to the
+  per-band frequency range. Closes #4.
+
+### Changed
+- `radio.freq_to_channel` 5 GHz formula simplified from
+  `(freq - 5170) // 5 + 34` to the algebraically equivalent
+  `(freq - 5000) // 5`, matching the natural 802.11 channel
+  convention (`channel = freq / 5 - 1000`) and making alignment
+  visible in the source.
+- `radio.freq_to_band` docstring now documents that band
+  classification is intentionally permissive (coarser than channel)
+  and refers callers to `freq_to_channel` for the strict mapping.
+
+### Added
+- Alignment-invariant Hypothesis properties for all three Wi-Fi bands
+  (`test_24ghz_alignment_invariant`, `test_5ghz_alignment_invariant`,
+  `test_6ghz_alignment_invariant`). These replace range-only
+  properties whose detection rate on this bug class was 3.4 %; the
+  new properties catch every off-grid mis-mapping (100 %).
+- Hand-written gap-band, off-grid, and band-boundary parametrised
+  tests in `tests/unit/test_radio.py::TestFrequencyToChannel`.
+
 ## [2.0.0] — 2026-05-05 — Public GA 🚀
 
 First public release after the v1.0.x → v2.0 rebuild. The package is

--- a/adb_android_control/radio.py
+++ b/adb_android_control/radio.py
@@ -36,20 +36,47 @@ logger = logging.getLogger(__name__)
 
 
 def freq_to_channel(freq_mhz: int) -> int:
-    """Convert Wi-Fi frequency (MHz) to channel number. Returns 0 if unknown."""
-    if 2412 <= freq_mhz <= 2484:
-        if freq_mhz == 2484:
-            return 14
+    """Convert Wi-Fi frequency (MHz) to IEEE 802.11 channel number.
+
+    Returns ``0`` if the frequency is not on the canonical channel-center
+    grid for any supported band.
+
+    The function validates *alignment* to the per-band 5 MHz grid in
+    addition to the per-band frequency range. Off-grid inputs (gap-band
+    frequencies, sub-MHz offsets) return ``0`` rather than a fictional
+    channel number — see issue #4.
+
+    Channel plans:
+
+    - 2.4 GHz: channels 1–13 at ``2412 + 5 * (n - 1)`` MHz; channel 14
+      alone at 2484 MHz. Frequencies 2473–2483 are the 12 MHz gap and
+      have no channel.
+    - 5 GHz: ``channel = (freq - 5000) / 5``; valid centers fall in
+      ``[5170, 5825]`` (channels 34–165).
+    - 6 GHz: channels 1, 5, 9, …, 233 at ``5955 + 5 * (n - 1)`` MHz.
+    """
+    # 2.4 GHz: channels 1-13 at 2412+5*(n-1) MHz; channel 14 alone at 2484.
+    if 2412 <= freq_mhz <= 2472 and (freq_mhz - 2412) % 5 == 0:
         return (freq_mhz - 2412) // 5 + 1
-    if 5170 <= freq_mhz <= 5825:
-        return (freq_mhz - 5170) // 5 + 34
-    if 5955 <= freq_mhz <= 7115:  # 6 GHz
+    if freq_mhz == 2484:
+        return 14
+    # 5 GHz: channel = (freq - 5000) / 5; valid in [5170, 5825].
+    if 5170 <= freq_mhz <= 5825 and (freq_mhz - 5000) % 5 == 0:
+        return (freq_mhz - 5000) // 5
+    # 6 GHz: channels 1, 5, 9, ..., 233 at 5955+5*(n-1) MHz.
+    if 5955 <= freq_mhz <= 7115 and (freq_mhz - 5955) % 5 == 0:
         return (freq_mhz - 5955) // 5 + 1
     return 0
 
 
 def freq_to_band(freq_mhz: int) -> str:
-    """Convert Wi-Fi frequency (MHz) to band name."""
+    """Convert Wi-Fi frequency (MHz) to band name.
+
+    Permissive by design: any frequency inside a band's overall envelope
+    returns the band string, even if it is not on the canonical
+    channel-center grid. Band classification is a coarser concept than
+    channel number — see :func:`freq_to_channel` for the strict mapping.
+    """
     if 2400 <= freq_mhz <= 2500:
         return "2.4GHz"
     if 5150 <= freq_mhz <= 5850:

--- a/docs/TESTING_DOCTRINE.md
+++ b/docs/TESTING_DOCTRINE.md
@@ -110,6 +110,31 @@ operations succeeded. Cron jobs, gitignore patterns, and async
 side-effects all benefit from explicit post-conditions verified
 against ground truth.
 
+### Range-only properties miss alignment bugs (issue #4, 2026-05-05)
+
+**Trigger:** `freq_to_channel` Hypothesis property
+`assert 1 <= ch <= 14` caught **2 of 59** in-band off-grid mis-mappings
+(detection rate **3.4 %**). The other 57 wrong outputs stayed inside
+`[1, 14]` and slipped through.
+
+**Insight:** For lookup-table-shaped functions (freq → channel,
+vid → vendor, currency code → name, etc.), a property of the form
+`assert lo <= f(x) <= hi` checks only that the output stays in its
+legal range — it is silent on whether the *right input* produced the
+*right output*. The stronger invariant asserts **structural
+alignment** between input and output: e.g. `if ch != 0: freq == 2412 +
+(ch - 1) * 5`. Cost is similar; detection on this bug class jumps from
+3.4 % to 100 %.
+
+**Pattern reinforced:** Property-based fuzzing (§ Advanced Patterns) +
+Adaptive Fault Tolerance — the alignment property captures the
+function's contract precisely, including the "0 means unknown"
+graceful-degradation clause.
+
+**Mitigation:** PR #9 replaces the two range-only 2.4 / 5 GHz
+properties with alignment-invariant ones, adds a previously-missing
+6 GHz alignment property, and lands the production fix.
+
 ### v1.0.0 PII leak (2026-05-05)
 
 The `.gitignore` had `.env` and `device_*.txt` patterns but

--- a/tests/property/test_parsers.py
+++ b/tests/property/test_parsers.py
@@ -66,18 +66,48 @@ class TestFreqToChannelProperties:
         assert isinstance(result, int)
 
     @SHALLOW_FUZZ
-    @given(freq=st.integers(min_value=2412, max_value=2484))
-    def test_24ghz_band_returns_channel_1_to_14(self, freq: int) -> None:
-        # Property: in 2.4 GHz range, channel must be 1-14
+    @given(freq=st.integers(min_value=2400, max_value=2500))
+    def test_24ghz_alignment_invariant(self, freq: int) -> None:
+        # Property (issue #4): if the function returns a non-zero channel,
+        # the input MUST sit on the canonical 2.4 GHz channel-center grid.
+        # A range-only assertion (1 <= ch <= 14) hides 57 of 59 off-grid
+        # mis-mappings; alignment catches all of them.
         ch = freq_to_channel(freq)
-        assert 1 <= ch <= 14
+        if ch == 0:
+            return  # 0 = "unknown" — any input is allowed to map to 0
+        if ch == 14:
+            assert freq == 2484, f"ch=14 must come from freq=2484, got {freq}"
+        else:
+            assert 1 <= ch <= 13, f"2.4 GHz channel out of [1,13] ∪ {{14}}: {ch}"
+            assert freq == 2412 + (ch - 1) * 5, (
+                f"Off-grid 2.4 GHz: freq={freq} fabricated ch={ch}"
+            )
 
     @SHALLOW_FUZZ
-    @given(freq=st.integers(min_value=5170, max_value=5825))
-    def test_5ghz_band_yields_positive_channel(self, freq: int) -> None:
-        # Property: in 5 GHz range, channel must be >= 36 (lowest 5 GHz channel)
+    @given(freq=st.integers(min_value=5000, max_value=5900))
+    def test_5ghz_alignment_invariant(self, freq: int) -> None:
+        # Property (issue #4): 5 GHz channel n satisfies freq = 5000 + 5*n.
+        # Generator capped at 5900 to avoid overlap with the 6 GHz envelope
+        # (which begins at 5955); any freq above 5825 returns 0 anyway.
         ch = freq_to_channel(freq)
-        assert ch >= 34
+        if ch == 0:
+            return
+        assert freq == 5000 + ch * 5, (
+            f"Off-grid 5 GHz: freq={freq} fabricated ch={ch}"
+        )
+
+    @SHALLOW_FUZZ
+    @given(freq=st.integers(min_value=5900, max_value=7200))
+    def test_6ghz_alignment_invariant(self, freq: int) -> None:
+        # Property (issue #4): 6 GHz channel n satisfies freq = 5955 + 5*(n-1).
+        # Generator starts at 5900 to avoid overlap with the 5 GHz envelope
+        # (which ends at 5825); any freq below 5955 returns 0 anyway.
+        ch = freq_to_channel(freq)
+        if ch == 0:
+            return
+        assert freq == 5955 + (ch - 1) * 5, (
+            f"Off-grid 6 GHz: freq={freq} fabricated ch={ch}"
+        )
 
     @example(freq=-1)
     @example(freq=0)

--- a/tests/unit/test_radio.py
+++ b/tests/unit/test_radio.py
@@ -41,6 +41,7 @@ class TestFrequencyToChannel:
             (2412, 1),
             (2437, 6),
             (2462, 11),
+            (2472, 13),
             (2484, 14),  # special-case channel 14
             # 5 GHz
             (5180, 36),
@@ -48,7 +49,7 @@ class TestFrequencyToChannel:
             (5825, 165),
             # 6 GHz
             (5955, 1),
-            (5980, 6),
+            (5975, 5),
             (7115, 233),
             # Out of range → 0
             (1, 0),
@@ -61,6 +62,43 @@ class TestFrequencyToChannel:
     ) -> None:
         # Arrange + Act + Assert
         assert freq_to_channel(freq) == expected_channel
+
+    # ------------------------------------------------------------------
+    # Issue #4 — off-grid frequencies must return 0, not a fictional
+    # channel number. Hand-written cases complement the alignment-
+    # invariant Hypothesis properties.
+    # ------------------------------------------------------------------
+
+    @pytest.mark.parametrize("freq", [2473, 2474, 2477, 2480, 2483])
+    def test_24ghz_gap_band_returns_zero(self, freq: int) -> None:
+        # The 12 MHz gap between channel 13 (2472) and channel 14 (2484)
+        # has no channel; the buggy implementation mapped these to 13/14/15.
+        assert freq_to_channel(freq) == 0
+
+    @pytest.mark.parametrize("freq", [2413, 2414, 2415, 2416, 2418, 2438])
+    def test_24ghz_off_grid_returns_zero(self, freq: int) -> None:
+        # Sub-5-MHz offsets inside the 2.4 GHz band must not be mapped.
+        assert freq_to_channel(freq) == 0
+
+    @pytest.mark.parametrize("freq", [5171, 5172, 5181, 5189, 5821, 5824])
+    def test_5ghz_off_grid_returns_zero(self, freq: int) -> None:
+        # 5 GHz frequencies not aligned to the 5 MHz channel grid (i.e.
+        # ``(freq - 5000) % 5 != 0``). Buggy implementation fabricated
+        # channels 34, 37, 164. Note: 5175 IS aligned (channel 35), so
+        # it is intentionally excluded here.
+        assert freq_to_channel(freq) == 0
+
+    @pytest.mark.parametrize("freq", [5956, 5957, 5974, 7114])
+    def test_6ghz_off_grid_returns_zero(self, freq: int) -> None:
+        # 6 GHz off-grid frequencies must return 0.
+        assert freq_to_channel(freq) == 0
+
+    @pytest.mark.parametrize(
+        "freq", [2411, 2485, 5169, 5826, 5954, 7116]
+    )
+    def test_band_boundary_just_outside_returns_zero(self, freq: int) -> None:
+        # One MHz outside any band's outer envelope must return 0.
+        assert freq_to_channel(freq) == 0
 
 
 class TestFrequencyToBand:


### PR DESCRIPTION
## Summary

- Adds alignment guards to all three Wi-Fi bands in `freq_to_channel` so off-grid frequencies return `0` instead of fabricated channel numbers.
- Replaces two weak range-only Hypothesis properties with alignment-invariant ones (3.4 % → 100 % detection on this bug class) and adds a missing 6 GHz property.
- Expands hand-written tests with 2.4 GHz gap-band, off-grid (2.4 / 5 / 6 GHz), and band-boundary cases.

Closes #4.

## Background

The reporter saw a single Hypothesis failure (`freq=2483 → ch=15`). Investigation showed the bug is **systemic**:

| Band | Wrong-rate | Example fabrications |
|---|---:|---|
| 2.4 GHz | 81 % (59 of 73 inputs) | 2473→13, 2480→14, 2483→15 |
| 5 GHz   | ~80 %                  | 5171→34, 5189→37, 5824→164 |
| 6 GHz   | ~80 %                  | parallel pattern |

Three downstream consumers (`WiFiInfo.channel`, `scan_results[].channel`, the CLI status printer) silently propagated the wrong values.

Full investigation archive: `memory/investigations/2026-05-05-freq-to-channel-rca/` (in the operator workspace).

## Production diff (10 lines effective)

| Change | Rationale |
|---|---|
| Tightened 2.4 GHz upper bound `<= 2484` → `<= 2472`; channel 14 moved to its own clause | Frequencies 2473–2483 are the 12 MHz gap and have no channel |
| `(freq - 2412) % 5 == 0` alignment guard on 2.4 GHz | Rejects sub-5-MHz offsets |
| `(freq - 5170) // 5 + 34` → `(freq - 5000) // 5` | Algebraically equivalent for canonical inputs; matches the natural 802.11 convention `channel = freq/5 - 1000` |
| `(freq - 5000) % 5 == 0` alignment guard on 5 GHz | Rejects off-grid 5 GHz |
| `(freq - 5955) % 5 == 0` alignment guard on 6 GHz | Same |

## Test changes

- `test_24ghz_band_returns_channel_1_to_14` (range-only) → `test_24ghz_alignment_invariant` (asserts `freq == 2412 + (ch-1)*5` when `ch != 0`).
- `test_5ghz_band_yields_positive_channel` → `test_5ghz_alignment_invariant` (`freq == 5000 + ch*5`).
- New `test_6ghz_alignment_invariant` (`freq == 5955 + (ch-1)*5`).
- New parametrised cases: `test_24ghz_gap_band_returns_zero`, `test_24ghz_off_grid_returns_zero`, `test_5ghz_off_grid_returns_zero`, `test_6ghz_off_grid_returns_zero`, `test_band_boundary_just_outside_returns_zero`.
- Existing canonical mapping table extended with `2472→13` and `5975→5`.

## `freq_to_band` audit

Kept permissive — band classification is intentionally coarser than channel mapping (useful for diagnostics on off-grid inputs). Documented in the docstring.

## Doctrine

| Law | Compliance |
|---|---|
| 1 — Never modify a test to fix CI | ✅ Production fix carries the change; the replaced properties were *strengthened*, not weakened |
| 2 — Test behaviour, not implementation | ✅ Alignment property tests the public contract |
| 3 — AAA pattern | ✅ |
| 9 — One concept per test | ✅ |
| 10 — No tautological tests | ✅ |

## Test plan

- [x] 59 targeted tests pass (`tests/unit/test_radio.py::TestFrequencyToChannel`, `tests/unit/test_radio.py::TestFrequencyToBand`, `tests/property/test_parsers.py::TestFreqToChannelProperties`, `tests/property/test_parsers.py::TestFreqToBandProperties`)
- [x] Full suite: 334 pass, 4 fail (pre-existing failures in `test_monitor.py` / `test_controller.py` re. `wm size` argv splitting; unrelated to this PR — verified by re-running on main with the patch stashed)
- [x] No regression in pre-existing canonical mappings (14 × 2.4 GHz + 6 × 5 GHz + 4 × 6 GHz)
- [ ] CI on Linux × Python 3.10 / 3.11 / 3.12 (will run automatically)
- [ ] CI on macOS (will run automatically)

## Doctrine lesson candidates (for `08-doctrine-lessons.md` follow-up)

1. **Range-only properties miss alignment bugs.** For lookup-table-shaped functions (channel numbers, vendor IDs, currency codes), an alignment property catches every wrong mapping; a range property catches only outputs that escape the range.
2. **Issue scope is a hypothesis to verify.** The reporter saw 1 manifestation; the truth was 60×. Always sweep the input domain before estimating effort.

🤖 Generated with [Claude Code](https://claude.com/claude-code)