### PR TITLE
docs(readme): refresh stale numbers + project status post v2.0 GA

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 [![Python](https://img.shields.io/badge/python-3.10%2B-blue.svg)](https://www.python.org/)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Doctrine](https://img.shields.io/badge/Master%20Tester%20Doctrine-1.0-purple.svg)](docs/TESTING_DOCTRINE.md)
-[![Tests](https://img.shields.io/badge/tests-273-brightgreen.svg)](tests/)
-[![Test ratio](https://img.shields.io/badge/test%2Fcode-1.56%3A1-brightgreen.svg)](tests/)
+[![Tests](https://img.shields.io/badge/tests-338-brightgreen.svg)](tests/)
+[![Test ratio](https://img.shields.io/badge/test%2Fcode-1.59%3A1-brightgreen.svg)](tests/)
 [![Type check](https://img.shields.io/badge/mypy-strict-blue.svg)](pyproject.toml)
 [![Pre-commit](https://img.shields.io/badge/pre--commit-enabled-orange.svg)](.pre-commit-config.yaml)
 
@@ -31,8 +31,8 @@ adb-control workflow ./my-test.json
 Built around three principles:
 
 1. **Behavioural test contracts.** Every public method has a typed test
-   exercising the failure mode it claims to handle. 273 tests today,
-   1.56 : 1 test/code ratio.
+   exercising the failure mode it claims to handle. 338 tests today,
+   1.59 : 1 test/code ratio.
 2. **No hidden subprocess interleaving.** Every shell-out goes through
    `ADBController` (or one flagged streaming carve-out). No `shell=True`
    anywhere. Argv lists only.
@@ -45,7 +45,7 @@ Built around three principles:
 ### As a Python package
 
 ```bash
-# From source (until PyPI publish in Phase 7)
+# From source (PyPI publish pending)
 pip install -e ".[dev]"
 
 # Or just the runtime dependencies
@@ -112,7 +112,7 @@ adb-control monitor crash            # crash detector
 adb-control radio                    # WiFi + Bluetooth status
 adb-control workflow ./test.json     # run an automation workflow
 adb-control health                   # JSON health check
-adb-control --version                # 1.1.0-rc1
+adb-control --version                # 2.0.0
 ```
 
 ### 4. Author a workflow
@@ -188,7 +188,7 @@ This project is governed by the **Master Tester Doctrine** (HH directive
 ### Run the tests
 
 ```bash
-pytest                       # 273 tests; ~10–20K Hypothesis examples
+pytest                       # 338 tests; ~10-20K Hypothesis examples
 pytest -m unit               # unit only (default)
 pytest -m property           # property-based fuzzing
 pytest -m race               # threading + concurrency
@@ -203,14 +203,14 @@ pytest --cov                 # coverage report
 | 1. Test foundation + 8 modules | ✅ `phase-1b-complete` |
 | 2. Code quality + CLI | ✅ `phase-2-complete` |
 | 3. Hypothesis + race + failure injection | ✅ `phase-3-complete` |
-| 4. Documentation | 🟡 in progress |
-| 5. Discoverability | ⏸️ |
-| 6. Visual polish (logo + GIFs) | ⏸️ |
-| 7. CI matrix + Codecov + CodeQL | ⏸️ |
-| 8. v2.0 GA | ⏸️ |
+| 4. Documentation | ✅ shipped with v2.0 GA |
+| 5. Discoverability | ✅ shipped with v2.0 GA |
+| 6. Visual polish (logo + GIFs) | 🟡 in progress |
+| 7. CI matrix + Codecov + CodeQL | ✅ shipped with v2.0 GA |
+| 8. v2.0 GA | ✅ **2026-05-05** 🚀 |
 
-Currently in **private development** ahead of v2.0 public release.
-Roadmap and phase deliverables are tracked in `CHANGELOG.md`.
+**Public GA shipped 2026-05-05** (v2.0.0 — see [CHANGELOG](CHANGELOG.md)).
+Roadmap and per-release deliverables are tracked in `CHANGELOG.md`.
 
 ## Documentation
 
@@ -229,8 +229,8 @@ Roadmap and phase deliverables are tracked in `CHANGELOG.md`.
 
 ## Contributing
 
-PRs welcome once we hit v2.0 public. For now, see
-[`CONTRIBUTING.md`](CONTRIBUTING.md) for the doctrine-aligned workflow.
+PRs welcome — see [`CONTRIBUTING.md`](CONTRIBUTING.md) for the
+doctrine-aligned workflow.
 
 ## License
 


### PR DESCRIPTION
## Summary

README was carrying pre-GA numbers and an "in progress" status table even though v2.0.0 shipped 2026-05-05 (CHANGELOG entry: *"Public GA 🚀"*). All changes are verifiable against ground truth.

## Verifiable corrections

| Item | Before | After | Source of truth |
|---|---|---|---|
| Tests badge | 273 | 338 | `pytest --collect-only -q` |
| Tests body text | 273 | 338 | same |
| Test/code ratio | 1.56:1 | 1.59:1 | `wc -l` → 4730 test LOC / 2975 prod LOC |
| CLI version example | `1.1.0-rc1` | `2.0.0` | `pyproject.toml:version` |
| Install comment | "until PyPI publish in Phase 7" | "PyPI publish pending" | Phase 7 shipped per CHANGELOG |

## Project status table

| Phase | Was | Now | Why |
|---|---|---|---|
| 4. Documentation | 🟡 in progress | ✅ shipped with v2.0 GA | CHANGELOG lists 8 docs in v2.0.0 |
| 5. Discoverability | ⏸️ | ✅ shipped with v2.0 GA | Public GA happened |
| 6. Visual polish | ⏸️ | 🟡 in progress | Best-guess; logo/GIFs are usually post-GA polish |
| 7. CI matrix + Codecov + CodeQL | ⏸️ | ✅ shipped with v2.0 GA | CHANGELOG: *"CI matrix: Python 3.10 / 3.11 / 3.12 × Linux / macOS"*, *"CodeQL + gitleaks + Dependabot integrated"* |
| 8. v2.0 GA | ⏸️ | ✅ **2026-05-05** 🚀 | CHANGELOG: `## [2.0.0] — 2026-05-05 — Public GA 🚀` |

## Status blurb + contributing

- *"Currently in private development ahead of v2.0 public release"* → *"Public GA shipped 2026-05-05"*
- *"PRs welcome once we hit v2.0 public"* → *"PRs welcome"*

## What didn't change

Architecture diagram, install commands, CLI examples, workflow JSON example, doctrine references, documentation table — already accurate. No content beyond stale metadata was touched.

## Test plan

- [x] All numbers cross-checked against the source files (pyproject.toml, CHANGELOG.md, `pytest --collect-only`, `wc -l`).
- [ ] CI (markdown links unchanged, no code changes — should be a no-op for lint/tests).
- [ ] Maintainer reviews Phase 6 status (best-guess "🟡 in progress" — feel free to override to ⏸️ or ✅ if you know the actual state).

🤖 Generated with [Claude Code](https://claude.com/claude-code)