### PR TITLE
chore: sync stale 273-tests / 1.76:1-ratio numbers to v2.0.1 reality

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,11 +5,11 @@
     "url": "https://github.com/hah23255/adb-android-control"
   },
   "metadata": {
-    "description": "Comprehensive Android device control via ADB \u2014 typed Python package + CLI + Claude Code skill, doctrine-tested with 273 tests",
-    "version": "2.0.0",
+    "description": "Comprehensive Android device control via ADB \u2014 typed Python package + CLI + Claude Code skill, doctrine-tested with 338 tests",
+    "version": "2.0.1",
     "license": "MIT",
     "created": "2025-12-25",
-    "updated": "2026-05-05"
+    "updated": "2026-05-06"
   },
   "plugins": [
     {

--- a/assets/demos/01-quickstart.tape
+++ b/assets/demos/01-quickstart.tape
@@ -44,6 +44,6 @@ Enter
 Sleep 2.5s
 
 # ── epilogue ──────────────────────────────────────────────────────────
-Type "# 273 tests · 1.76:1 ratio · MIT"
+Type "# 338 tests · 1.59:1 ratio · MIT"
 Enter
 Sleep 2s

--- a/assets/social/og-banner.svg
+++ b/assets/social/og-banner.svg
@@ -47,14 +47,14 @@
 
   <!-- Stats row -->
   <g font-family="ui-sans-serif, system-ui, sans-serif">
-    <!-- 273 tests -->
+    <!-- 338 tests -->
     <g transform="translate(80,400)">
-      <text font-size="56" fill="#83c5be" font-weight="700">273</text>
+      <text font-size="56" fill="#83c5be" font-weight="700">338</text>
       <text x="0" y="32" font-size="18" fill="#778da9">tests</text>
     </g>
-    <!-- 1.76:1 ratio -->
+    <!-- 1.59:1 ratio -->
     <g transform="translate(280,400)">
-      <text font-size="56" fill="#83c5be" font-weight="700">1.76:1</text>
+      <text font-size="56" fill="#83c5be" font-weight="700">1.59:1</text>
       <text x="0" y="32" font-size="18" fill="#778da9">test/code ratio</text>
     </g>
     <!-- 9 modules -->


### PR DESCRIPTION
## Summary

The README refresh (#11) and v2.0.1 release (#12) corrected the README + repo description, but three other surfaces still carried the pre-fix numbers. This PR sweeps them to match.

## Changes

| File | Why it matters |
|---|---|
| `.claude-plugin/marketplace.json` | Description visible to Claude Code marketplace consumers — was "273 tests" + version "2.0.0". Now "338 tests" + "2.0.1". Updated date bumped to 2026-05-06. |
| `assets/social/og-banner.svg` | Open Graph social-share card. Was "273 tests / 1.76:1". Now "338 / 1.59:1". |
| `assets/demos/01-quickstart.tape` | vhs/asciinema demo script epilogue. Was `# 273 tests · 1.76:1 ratio · MIT`. Now `# 338 tests · 1.59:1 ratio · MIT`. |

## What was deliberately not changed

- `CHANGELOG.md` v2.0.0 entry — historical release notes are immutable; "273 tests" was correct on 2026-05-05. The v2.0.1 entry already documents the move to 338.
- The OG banner SVG colors / layout / fonts — only the two number values changed.

## Test plan

- [x] `git diff --cached --stat`: 3 files, 8 insertions, 8 deletions
- [x] No code touched; CI should pass cleanly (no test or lint impact)
- [ ] CI matrix runs automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)