### PR TITLE
test(controller): multi-display screenshot regression tests (companion to #17)

### DIFF
--- a/tests/unit/test_controller.py
+++ b/tests/unit/test_controller.py
@@ -470,3 +470,44 @@ class TestKeyEvents:
             "shell",
             f"input keyevent {expected_keycode}",
         ) in mock_adb.call_log()
+
+
+class TestScreenshot:
+    """screencap output handling, including multi-display warning banners."""
+
+    def test_screenshot_strips_multidisplay_warning_prefix(
+        self, mock_adb: PoisonPillADB, tmp_path: Path
+    ) -> None:
+        # Arrange — foldables print a banner to stdout ahead of the PNG bytes.
+        png_body = b"\x89PNG\r\n\x1a\n\x00\x01real-image-bytes"
+        banner = b"[Warning] Multiple displays were found...\n"
+        mock_adb.register(["adb", "version"], stdout="v1\n")
+        mock_adb.register(
+            ["adb", "exec-out", "screencap", "-p"],
+            stdout=banner + png_body,  # type: ignore[arg-type]
+        )
+        ctrl = ADBController()
+        out = tmp_path / "shot.png"
+
+        # Act
+        ok = ctrl.screenshot(out)
+
+        # Assert — banner stripped, file is a valid PNG.
+        assert ok is True
+        assert out.read_bytes() == png_body
+
+    def test_screenshot_fails_cleanly_when_no_png_present(
+        self, mock_adb: PoisonPillADB, tmp_path: Path
+    ) -> None:
+        # Arrange
+        mock_adb.register(["adb", "version"], stdout="v1\n")
+        mock_adb.register(
+            ["adb", "exec-out", "screencap", "-p"],
+            stdout=b"error: no image",  # type: ignore[arg-type]
+        )
+        ctrl = ADBController()
+        out = tmp_path / "shot.png"
+
+        # Act + Assert — no PNG signature => failure, nothing written.
+        assert ctrl.screenshot(out) is False
+        assert not out.exists()


### PR DESCRIPTION
## Tests for the multi-display screenshot fix (companion to #17)

Adds two regression tests for `ADBController.screenshot()` (from #17):
- `test_screenshot_strips_multidisplay_warning_prefix` — a `[Warning] Multiple displays` banner ahead of the PNG is stripped; the written file is a valid PNG.
- `test_screenshot_fails_cleanly_when_no_png_present` — no PNG signature ⇒ returns `False`, writes nothing.

### Why this is a separate PR
CI **Doctrine Law 1** (`test-file-integrity`) blocks any `tests/**` change in the same PR as a code fix. These are *new* tests for new behaviour, not a test edit to game CI — but the gate can't tell the difference, so per the doctrine's own guidance they're split out here for explicit sign-off.

- **Base:** `fix/v2.0.2-packaging-foldable-version` (#17), so the diff is tests-only and they run against the screenshot fix. Retarget to `main` after #17 merges.
- **Expected CI:** tests pass (340 with the fix present); the `Law 1` job will report red by design and needs your override/sign-off to merge.