### PR TITLE
docs: multi-display/proot troubleshooting + E060 error entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `docs/TROUBLESHOOTING.md` — Termux/proot LAN-vs-loopback (`ENOSYS`) guidance and
+  runaway reconnect-loop recovery (section C); expanded multi-display screenshot banner
+  diagnosis (section G).
+- `docs/ERROR_HANDLING.md` — **E060**: corrupt screenshot on multi-display devices, with
+  the PNG-signature check and the safe capture-then-pull path.
+
 ## [2.0.2] — 2026-07-05 — Packaging, foldable & version-metadata fixes
 
 ### Fixed

--- a/docs/ERROR_HANDLING.md
+++ b/docs/ERROR_HANDLING.md
@@ -9,8 +9,9 @@ Comprehensive guide to ADB errors, their causes, and solutions.
 3. [Permission Errors](#permission-errors)
 4. [File Operation Errors](#file-operation-errors)
 5. [Shell Command Errors](#shell-command-errors)
-6. [Performance Issues](#performance-issues)
-7. [Error Codes Reference](#error-codes-reference)
+6. [Media Capture Errors](#media-capture-errors)
+7. [Performance Issues](#performance-issues)
+8. [Error Codes Reference](#error-codes-reference)
 
 ---
 
@@ -477,6 +478,39 @@ adb shell pwd
 # Instead of: adb shell rm /sdcard/photos/*
 adb shell "cd /sdcard/photos && find . -type f -delete"
 ```
+
+---
+
+## Media Capture Errors
+
+### E060: Corrupt Screenshot on Multi-Display Devices
+
+```
+# ctrl.screenshot("shot.png") returns True, but the file won't open.
+# First bytes are text, e.g.:
+[Warning] Multiple displays were found, but no display id was specified! ...
+```
+
+**Cause**
+
+On foldables and other multi-display devices, `screencap` writes a warning banner to
+**stdout ahead of the PNG**, so the captured stream no longer begins with the PNG
+signature. `screencap -d 0` does not fix it — such devices reject display id `0`.
+
+**Handling**
+
+`ADBController.screenshot()` (v2.0.0+) searches for the PNG signature (`\x89PNG`) and
+strips any preceding bytes before writing; if no signature is present it logs an error and
+returns `False` (rather than writing a corrupt file). To detect this in your own code,
+check the file header:
+
+```python
+assert open("shot.png", "rb").read(8) == b"\x89PNG\r\n\x1a\n"
+```
+
+If you shell out to `adb` directly, prefer the capture-then-pull path
+(`adb shell screencap -p /sdcard/shot.png && adb pull ...`), which avoids the stdout banner
+entirely. See TROUBLESHOOTING.md → "G. Screenshot".
 
 ---
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -157,6 +157,17 @@ To find the new pairing/connection ports:
   pairing code" (gives a new pair port + code) or read the connection
   port from the same screen.
 
+**On Termux / proot (running on the phone itself)**
+
+- Connect to the phone's **LAN IP** (its `wlan0` address), **not** `127.0.0.1`. Inside a
+  proot container the network namespace returns `ENOSYS` on a loopback `adb connect`
+  (`failed to connect ... Function not implemented`), so the loopback bridge never comes
+  up even though the port is open.
+- A loopback `adb connect` to a dead target can then loop forever: the adb server retries
+  the (unreachable) target every ~3 s, burning ~80 % of a CPU core indefinitely. Clear it
+  with `adb disconnect <target>`; if the server is wedged and ignores the disconnect, kill
+  the `adb -L tcp:5037 fork-server` PID — it respawns clean without the stale target.
+
 ---
 
 ## D. Device shows as `offline`
@@ -257,18 +268,33 @@ ctrl.screenshot("shot.png")  # returns True
 
 **Diagnosis**
 
-`exec-out` adds `\r\n` line endings on some devices, corrupting the
-PNG stream. `adb_android_control` uses `exec-out` (no shell-wrap) which
-is the correct path; but adb versions < 1.0.40 may still corrupt.
+Two known causes:
+
+1. `exec-out` adds `\r\n` line endings on some devices, corrupting the PNG stream.
+   `adb_android_control` uses `exec-out` (no shell-wrap), the correct path; adb
+   versions < 1.0.40 may still corrupt.
+2. **Multi-display devices (foldables such as the Z Fold7)** — `screencap` prints
+   `[Warning] Multiple displays were found...` to **stdout, ahead of the PNG**. Raw
+   `adb exec-out screencap -p > shot.png` therefore produces a file whose first ~350
+   bytes are warning text and which no viewer will open. Note `screencap -d 0` does not
+   help — foldables reject display id `0`.
+
+Confirm which one by inspecting the first bytes — a valid PNG starts with `89 50 4E 47`:
+
+```bash
+head -c 16 shot.png | xxd        # expect: 8950 4e47 0d0a 1a0a ...
+```
 
 **Fix**
 
-```bash
-# Verify adb version
-adb version
-# Upgrade if < 1.0.40
+`screenshot()` (v2.0.0+) locates the PNG signature and strips any preceding bytes, so the
+toolkit handles the multi-display banner automatically. If you are calling `adb` directly:
 
-# Workaround: use shell + base64
+```bash
+# Verify adb version (upgrade if < 1.0.40)
+adb version
+
+# Safe path that avoids the stdout banner entirely: capture on-device, then pull
 adb shell screencap -p /sdcard/shot.png
 adb pull /sdcard/shot.png ./shot.png
 adb shell rm /sdcard/shot.png


### PR DESCRIPTION
## What

Adds the troubleshooting/error-handling docs from earlier local work that were **not** carried into the v2.0.2 packaging PR (#17). Docs-only — no code or test changes, so no Doctrine Law-1 / codecov interaction.

## Changes

- **`docs/TROUBLESHOOTING.md`**
  - **C. Wireless ADB reconnect** — new *Termux / proot (on the phone itself)* block: connect to the phone's **LAN IP**, not `127.0.0.1` (inside proot a loopback `adb connect` returns `ENOSYS` / "Function not implemented"); and how to clear the runaway reconnect loop that burns ~80% of a CPU core against a dead target.
  - **G. Screenshot** — expanded diagnosis to two causes (the `\r\n` corruption *and* the multi-display `screencap` stdout banner on foldables), a `head -c 16 … | xxd` PNG-header check, and the safe capture-then-pull path.
- **`docs/ERROR_HANDLING.md`** — new **E060: Corrupt Screenshot on Multi-Display Devices** (cause, how `ADBController.screenshot()` handles it, PNG-signature self-check), plus a Table-of-Contents entry.
- **`CHANGELOG.md`** — `[Unreleased] → Added` notes.

## Why

The v2.0.2 code fix (`controller.screenshot()` banner-stripping) shipped in #17, but the matching operator-facing docs did not. These entries close that gap and capture the Termux/proot bridge gotchas discovered while running the toolkit on-device (Z Fold7 / SM-F966B).