### PR TITLE
fix: resolve 3 CodeQL notes (empty-except comments + unused global)

### DIFF
--- a/adb_android_control/monitor.py
+++ b/adb_android_control/monitor.py
@@ -231,6 +231,8 @@ class LogcatMonitor:
                     continue
                 callback(entry)
         except KeyboardInterrupt:
+            # Ctrl-C is the expected way to end a blocking stream; teardown
+            # happens in `finally`, so nothing to do here.
             pass
         finally:
             self.stop()
@@ -422,6 +424,8 @@ class EventMonitor:
                 else:
                     print(stripped)  # noqa: T201
         except KeyboardInterrupt:
+            # Ctrl-C is the expected way to end the capture loop; teardown
+            # happens in `finally`, so nothing to do here.
             pass
         finally:
             self.stop()

--- a/adb_android_control/usb.py
+++ b/adb_android_control/usb.py
@@ -126,9 +126,8 @@ def identify_via_fd(fd: int) -> USBDeviceInfo | None:
     return parse_device_descriptor(data)
 
 
-# USBDEVFS ioctl constants — Linux-specific.
+# USBDEVFS ioctl constant — Linux-specific.
 # Source: linux/usb/usbdevice_fs.h
-_USBDEVFS_CONNECTINFO = 0x5411
 _USBDEVFS_CONTROL = 0xC0185500
 
 


### PR DESCRIPTION
## What

Clears the 3 open CodeQL code-scanning alerts (all severity *note*). Code-only, no `tests/**` changes → no Doctrine Law-1 interaction.

| Alert | Rule | Location | Fix |
|---|---|---|---|
| #7 | `py/empty-except` | `monitor.py:233` | Explanatory comment (the `pass` is intentional) |
| #8 | `py/empty-except` | `monitor.py:424` | Explanatory comment (the `pass` is intentional) |
| #1 | `py/unused-global-variable` | `usb.py:131` | Remove the unused `_USBDEVFS_CONNECTINFO` constant |

## Details

- **`monitor.py`** — both flagged blocks are `except KeyboardInterrupt: pass`. The `pass` is correct: Ctrl-C is the expected way to end the blocking log **stream** / capture loop, and cleanup already runs in the `finally: self.stop()`. CodeQL's own message asks for an explanatory comment, so each block now documents why it is empty. Behavior unchanged.
- **`usb.py`** — `_USBDEVFS_CONNECTINFO = 0x5411` was defined but referenced nowhere (`git grep` confirms). Removed it; the comment is now singular. `_USBDEVFS_CONTROL` is untouched and still used by the `fcntl.ioctl` call.

## Verification

- `ruff check` → all checks passed
- `ast.parse` → OK
- No runtime behavior change (comments + one dead module constant removed).