### PR TITLE
[doctrine-exception] refactor(monitor): shared probe-command constants (#7 hardening)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `docs/ERROR_HANDLING.md` — **E060**: corrupt screenshot on multi-display devices, with
   the PNG-signature check and the safe capture-then-pull path.
 
+### Changed
+- `PerformanceMonitor` — the four device probe commands (`cpu`, `memory`, `disk`,
+  `process-count`) are now module-level constants (`_CPU_PROBE_CMD` &c.) shared by the
+  production code and its tests, so the two can no longer silently drift. Prevents the
+  regression class behind issue #7 (a fixture/production string mismatch that routed every
+  reading to the graceful-degradation `0.0` path). No runtime behavior change.
+
 ## [2.0.2] — 2026-07-05 — Packaging, foldable & version-metadata fixes
 
 ### Fixed

--- a/adb_android_control/monitor.py
+++ b/adb_android_control/monitor.py
@@ -251,6 +251,15 @@ _CPU_PCT_RE = re.compile(r"(\d+(?:\.\d+)?)\s*%")
 _MEMINFO_KB_RE = re.compile(r"(\d+)")
 _DISK_PCT_RE = re.compile(r"(\d+)%")
 
+# Device shell commands issued by the performance probes. Kept as module-level
+# constants so tests reference the exact same string the production code sends
+# (a whitespace/quoting drift between the two silently sent every snapshot's
+# reading to the graceful-degradation 0.0 path — see issue #7).
+_CPU_PROBE_CMD = "top -n 1 -b | grep -E 'CPU|cpu' | head -1"
+_MEMORY_PROBE_CMD = "cat /proc/meminfo | head -3"
+_DISK_PROBE_CMD = "df /data | tail -1"
+_PROCESS_COUNT_PROBE_CMD = "ps -A | wc -l"
+
 
 class PerformanceMonitor:
     """Periodic device-performance snapshots.
@@ -297,7 +306,7 @@ class PerformanceMonitor:
 
     def _get_cpu_usage(self) -> float:
         try:
-            output = self.adb.shell("top -n 1 -b | grep -E 'CPU|cpu' | head -1")
+            output = self.adb.shell(_CPU_PROBE_CMD)
         except Exception:  # noqa: BLE001 — degraded path: any failure → 0
             return 0.0
         match = _CPU_PCT_RE.search(output)
@@ -305,7 +314,7 @@ class PerformanceMonitor:
 
     def _get_memory(self) -> dict[str, int]:
         try:
-            output = self.adb.shell("cat /proc/meminfo | head -3")
+            output = self.adb.shell(_MEMORY_PROBE_CMD)
         except Exception:  # noqa: BLE001
             return {"total": 0, "used": 0}
         total = used = 0
@@ -322,7 +331,7 @@ class PerformanceMonitor:
 
     def _get_disk_usage(self) -> float:
         try:
-            output = self.adb.shell("df /data | tail -1")
+            output = self.adb.shell(_DISK_PROBE_CMD)
         except Exception:  # noqa: BLE001
             return 0.0
         match = _DISK_PCT_RE.search(output)
@@ -330,7 +339,7 @@ class PerformanceMonitor:
 
     def _get_process_count(self) -> int:
         try:
-            output = self.adb.shell("ps -A | wc -l")
+            output = self.adb.shell(_PROCESS_COUNT_PROBE_CMD)
         except Exception:  # noqa: BLE001
             return 0
         try:

--- a/tests/unit/test_monitor.py
+++ b/tests/unit/test_monitor.py
@@ -28,6 +28,10 @@ from freezegun import freeze_time
 
 from adb_android_control.controller import ADBController, ADBError
 from adb_android_control.monitor import (
+    _CPU_PROBE_CMD,
+    _DISK_PROBE_CMD,
+    _MEMORY_PROBE_CMD,
+    _PROCESS_COUNT_PROBE_CMD,
     CrashEvent,
     CrashMonitor,
     LogcatMonitor,
@@ -211,14 +215,14 @@ class TestPerformanceMonitor:
         # Arrange
         adb = _make_mock_controller(
             **{
-                "top -n 1 -b | grep -E 'CPU|cpu' | head -1": "  user 23.5%  sys 5.0%",
-                "cat /proc/meminfo | head -3": (
+                _CPU_PROBE_CMD: "  user 23.5%  sys 5.0%",
+                _MEMORY_PROBE_CMD: (
                     "MemTotal:        8000000 kB\n"
                     "MemFree:         2000000 kB\n"
                     "MemAvailable:    4000000 kB"
                 ),
-                "df /data | tail -1": "/data 100G 50G 50G 50% /data",
-                "ps -A | wc -l": "247",
+                _DISK_PROBE_CMD: "/data 100G 50G 50G 50% /data",
+                _PROCESS_COUNT_PROBE_CMD: "247",
             }
         )
         mon = PerformanceMonitor(adb=adb)
@@ -247,9 +251,9 @@ class TestPerformanceMonitor:
         # Arrange — only register the queries that should succeed
         adb = _make_mock_controller(
             **{
-                "cat /proc/meminfo | head -3": "MemTotal: 8000000 kB",
-                "df /data | tail -1": "/data 50% /data",
-                "ps -A | wc -l": "100",
+                _MEMORY_PROBE_CMD: "MemTotal: 8000000 kB",
+                _DISK_PROBE_CMD: "/data 50% /data",
+                _PROCESS_COUNT_PROBE_CMD: "100",
                 # CPU query intentionally NOT registered → ADBError → 0.0
             }
         )
@@ -267,10 +271,10 @@ class TestPerformanceMonitor:
         # Arrange
         adb = _make_mock_controller(
             **{
-                "top -n 1 -b | grep -E 'CPU|cpu' | head -1": "0% idle",
-                "cat /proc/meminfo | head -3": "MemTotal: 8000000 kB",
-                "df /data | tail -1": "/data 0%",
-                "ps -A | wc -l": "garbage_not_an_int",  # parse failure
+                _CPU_PROBE_CMD: "0% idle",
+                _MEMORY_PROBE_CMD: "MemTotal: 8000000 kB",
+                _DISK_PROBE_CMD: "/data 0%",
+                _PROCESS_COUNT_PROBE_CMD: "garbage_not_an_int",  # parse failure
             }
         )
         mon = PerformanceMonitor(adb=adb)


### PR DESCRIPTION
## What this PR does

Extracts the four `PerformanceMonitor` device-probe commands into module-level constants (`_CPU_PROBE_CMD`, `_MEMORY_PROBE_CMD`, `_DISK_PROBE_CMD`, `_PROCESS_COUNT_PROBE_CMD`) referenced by **both** the production probes and the test fixtures. This is the Option-C hardening from #7.

## Why

The original #7 failure (`test_take_snapshot_aggregates_all_probes` → `cpu_usage == 0.0`) was a silent **string drift** between the test fixture key and the production shell command: any whitespace/quoting difference routed every reading into the graceful-degradation `0.0` path. A single shared constant makes that drift structurally impossible.

## ⚠️ Doctrine Law 1 — read before reviewing

This PR modifies `tests/unit/test_monitor.py`, so the `test-file-integrity` gate will go **red by design**. Please read *why this is a legitimate exception, not a violation*:

> **Law 1** — *I did NOT modify a test to make CI pass.*

- **All 340 tests were green *before* this PR and are green *after* it.** #7's actual failure was already fixed by #10 (`657b30a`) months ago. I am **not** editing a test to turn a red CI green.
- The change is **production-driven**: it extracts constants in `monitor.py`; the fixture edit is the *incidental* consequence of pointing the test at the new single source of truth (exactly the case #7 anticipated: *"Option C also changes production code … the test edit is incidental, not the cause of CI green"*).
- **Spirit preserved:** "fix the code, not the screwdriver." Here the code *is* the fix (shared contract constant); the screwdriver just now points at it.

**Requested maintainer action:** merge despite the red `test-file-integrity` check, with an ack comment (e.g. `Law 1 exception accepted: production-driven refactor, suite green before+after`).

## Master Tester Doctrine compliance
- [x] **Law 1** — Test edit is incidental to a production refactor; suite was green before and after (documented above).
- [x] **Law 2** — Tests still target the public `take_snapshot()` behavior; the imported constants are the probe *contract*, not private-method assertions.
- [x] **Law 6** — Poison-Pill `spec_set` mock untouched.
- [x] No new public API surface; no runtime behavior change.

## Verification
- `ruff check` — clean · `ruff format --check` — clean
- `mypy --strict adb_android_control/monitor.py` — Success
- Full suite — **340 passed**

Follow-up to #7 (closed). CHANGELOG `[Unreleased] → Changed` updated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved performance monitoring reliability by keeping probe commands consistent between app behavior and tests, reducing the chance of mismatched results.
  * Preserved existing fallback behavior when a device probe fails, with no change to runtime output.

* **Documentation**
  * Updated the changelog to note the monitoring consistency fix and related regression prevention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->